### PR TITLE
Integrate deep link navigation for RecorderApp

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,25 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-    <component name="GradleSettings">
-        <option name="linkedExternalProjectSettings">
-            <GradleProjectSettings>
-                <option name="externalProjectPath" value="$PROJECT_DIR$" />
-                <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
-                <option name="modules">
-                    <set>
-                        <option value="$PROJECT_DIR$" />
-                        <option value="$PROJECT_DIR$/app" />
-                    </set>
-                </option>
-                <option name="resolveExternalAnnotations" value="false" />
-            </GradleProjectSettings>
-        </option>
-    </component>
-</project>
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="jbr-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -30,5 +17,4 @@
       </GradleProjectSettings>
     </option>
   </component>
-  <component name="GradleMigrationSettings" migrationVersion="1" />
 </project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,19 +3,15 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
@@ -31,27 +27,21 @@
     </inspection_tool>
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
-      <option name="previewFile" value="true" />
     </inspection_tool>
   </profile>
 </component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="2.0.20" />
   </component>
 </project>

--- a/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/data/service/NotificationHelper.kt
+++ b/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/data/service/NotificationHelper.kt
@@ -15,6 +15,7 @@ import com.ozodbek.recorderapp_jetpackcompose.R
 import com.ozodbek.recorderapp_jetpackcompose.common.IntentRequestCodes
 import com.ozodbek.recorderapp_jetpackcompose.common.LocalTimeFormats
 import com.ozodbek.recorderapp_jetpackcompose.domain.recorder.emums.RecorderAction
+import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.NavDeepLinks
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.format
 

--- a/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/data/service/VoiceRecorderService.kt
+++ b/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/data/service/VoiceRecorderService.kt
@@ -8,14 +8,10 @@ import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
-import com.eva.recorderapp.R
+import com.ozodbek.recorderapp_jetpackcompose.R
 import com.ozodbek.recorderapp_jetpackcompose.common.NotificationConstants
-import com.eva.recorderapp.common.Resource
-import com.eva.recorderapp.common.roundToClosestSeconds
-import com.eva.recorderapp.voice_recorder.domain.bookmarks.RecordingBookmarksProvider
-import com.eva.recorderapp.voice_recorder.domain.use_cases.BluetoothScoUseCase
-import com.eva.recorderapp.voice_recorder.domain.use_cases.PhoneStateObserverUsecase
-import com.eva.recorderapp.voice_recorder.domain.util.AppWidgetsRepository
+import com.ozodbek.recorderapp_jetpackcompose.common.Resource
+import com.ozodbek.recorderapp_jetpackcompose.common.roundToClosestSeconds
 import com.ozodbek.recorderapp_jetpackcompose.domain.recorder.emums.RecorderAction
 import com.ozodbek.recorderapp_jetpackcompose.domain.recorder.emums.RecorderState
 import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.NavRoutes

--- a/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/presentation/navigation/routes/RecorderRoute.kt
+++ b/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/presentation/navigation/routes/RecorderRoute.kt
@@ -2,6 +2,7 @@ package com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.routes
 
 
 
+import android.content.Intent
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.EaseInCubic
@@ -27,7 +28,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.navDeepLink
 import com.ozodbek.recorderapp_jetpackcompose.R
+import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.NavDeepLinks
 import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.NavRoutes
 import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.animatedComposable
 import com.ozodbek.recorderapp_jetpackcompose.presentation.recorder.RecorderServiceBinder
@@ -37,6 +40,12 @@ import com.ozodbek.recorderapp_jetpackcompose.presentation.recorder.VoiceRecorde
 fun NavGraphBuilder.recorderRoute(
     navController: NavHostController,
 ) = animatedComposable<NavRoutes.VoiceRecorder>(
+    deepLinks = listOf(
+        navDeepLink {
+            uriPattern = NavDeepLinks.recorderDestinationPattern
+            action = Intent.ACTION_VIEW
+        },
+    ),
 ) {
 
     val viewModel = hiltViewModel<RecorderViewModel>()

--- a/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/presentation/navigation/routes/RecordingsRoute.kt
+++ b/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/presentation/navigation/routes/RecordingsRoute.kt
@@ -1,5 +1,6 @@
 package com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.routes
 
+import android.content.Intent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
@@ -13,7 +14,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.navDeepLink
 import com.ozodbek.recorderapp_jetpackcompose.R
+import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.NavDeepLinks
 import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.NavDialogs
 import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.NavRoutes
 import com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util.animatedComposable
@@ -26,6 +29,12 @@ import com.ozodbek.recorderapp_jetpackcompose.presentation.recorgings.util.handl
 fun NavGraphBuilder.recordingsRoute(
     controller: NavController,
 ) = animatedComposable<NavRoutes.VoiceRecordings>(
+    deepLinks = listOf(
+        navDeepLink {
+            uriPattern = NavDeepLinks.recordingsDestinationPattern
+            action = Intent.ACTION_VIEW
+        },
+    ),
 ) {
 
     val lifecycleOwner = LocalLifecycleOwner.current

--- a/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/presentation/navigation/util/NavDeepLinks.kt
+++ b/app/src/main/java/com/ozodbek/recorderapp_jetpackcompose/presentation/navigation/util/NavDeepLinks.kt
@@ -1,0 +1,18 @@
+package com.ozodbek.recorderapp_jetpackcompose.presentation.navigation.util
+
+import androidx.core.net.toUri
+
+object NavDeepLinks {
+	private const val BASE_URI = "app://com.ozodbek.recorderapp_jetpackcompose"
+
+	const val recorderDestinationPattern = BASE_URI
+	val recorderDestinationUri = recorderDestinationPattern.toUri()
+
+	const val recordingsDestinationPattern = "$BASE_URI/recordings"
+	val recordingsDestinationUri = recordingsDestinationPattern.toUri()
+
+	const val appPlayerDestinationPattern = "$BASE_URI/player/{audioId}"
+
+
+	fun audioPlayerDestinationUri(id: Long) = (BASE_URI + "/player" + "/${id}").toUri()
+}


### PR DESCRIPTION
                            - Add  object for managing app deep link URIs.
                            - Update  to handle navigation with deep links.
                            - Add navigation routes for RecorderScreen, RecordingsScreen, and PlayerScreen.
                            - Support deep link URIs for navigation to recordings and audio player.
                            - Ensure seamless integration of Compose navigation with deep link handling.